### PR TITLE
Aktualisiere Hinweise zu optionalen Tcl-Erweiterungen

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ Das Skript `rss_synd.tcl` erweitert Eggdrop-Bots um die Möglichkeit, RSS- und A
 2. Ergänze deine `eggdrop.conf` um die Zeile `source scripts/rss-synd.tcl` (Pfad ggf. anpassen).
 
 ### Paketinstallation (optionale Features)
-| Feature | Benötigtes Paket | Debian/Ubuntu |
-|---------|------------------|----------------|
-| HTTP-Authentifizierung | `tcllib` (Base64) | `sudo apt-get install tcllib` |
-| HTTPS-Unterstützung | `tcl-tls` | `sudo apt-get install tcl-tls` |
-| Gzip-Dekomprimierung | `tcl-trf` | `sudo apt-get install tcl-trf` |
+Die folgenden optionalen Funktionen erfordern zusätzliche Tcl-Erweiterungen:
+
+| Feature | Benötigte Tcl-Erweiterungen |
+|---------|-----------------------------|
+| HTTP-Authentifizierung | `base64` aus `tcllib` |
+| HTTPS-Unterstützung | `tls` |
+| Gzip-Dekomprimierung | `Trf` |
+
+Installiere die benötigten Erweiterungen je nach Plattform über den jeweiligen Paketmanager, vorgefertigte Tcl-Pakete oder verfügbare Community-Repositorien.
 
 ## Abhängigkeiten und Hinweise
 Das Skript läuft ohne zusätzliche Pakete, jedoch sind bestimmte Funktionen nur mit den oben aufgeführten Erweiterungen verfügbar.


### PR DESCRIPTION
## Zusammenfassung
- ersetze die bisherige Paket-Tabelle durch eine Übersicht der benötigten Tcl-Erweiterungen je Feature
- passe den Hinweistext an, damit er ohne distributionsspezifische Paketnamen auskommt

## Tests
- keine

------
https://chatgpt.com/codex/tasks/task_e_68df382950d8832a842de17f1185ca64