### PR TITLE
Refine user-agent rotation defaults and documentation

### DIFF
--- a/rss-synd-settings.tcl
+++ b/rss-synd-settings.tcl
@@ -106,7 +106,16 @@ set rss(msbulletins) {
 		"channels"			"#channel"
 		"trigger"			"!rss @@feedid@@"
 		"output"			"\[\002@@channel!title@@@@title@@\002\] @@item!title@@@@entry!title@@ - @@item!link@@@@entry!link!=href@@"
-		"user-agent"			"Mozilla/5.0 (Windows; U; Windows NT 6.1; en-GB; rv:1.9.2.2) Gecko/20100316 Firefox/3.6.2"
+		"user-agent"			{
+				"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
+				"Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36"
+				"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+				"Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+				"Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+				"Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro Build/AP2A.240605.024) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.6533.72 Mobile Safari/537.36"
+				"Mozilla/5.0 (Linux; Android 14; SM-S928B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Mobile Safari/537.36"
+			}
+                "user-agent-rotate"             "list"
 		"https-allow-legacy"		0
 	}
 }

--- a/tests/rss_synd.test
+++ b/tests/rss_synd.test
@@ -8,10 +8,31 @@ proc botonchan {chan} { return 1 }
 proc is_utf8_patched {} { return 0 }
 proc bind {args} {}
 proc unbind {args} {}
+proc unixtime {} { clock seconds }
 
 set here [file dirname [info script]]
 namespace eval ::rss-synd {}
 source [file join $here .. rss_synd.tcl]
+
+namespace eval ::http {
+    variable lastUserAgents {}
+    variable tokenCounter 0
+
+    proc config {args} {
+        variable lastUserAgents
+        set index [lsearch -exact $args "-useragent"]
+        if {$index >= 0} {
+            lappend lastUserAgents [lindex $args [expr {$index + 1}]]
+        }
+        return {}
+    }
+
+    proc geturl {url args} {
+        variable tokenCounter
+        incr tokenCounter
+        return "token$tokenCounter"
+    }
+}
 
 namespace eval ::rss-synd { variable packages }
 
@@ -78,5 +99,80 @@ test xml_list_create_partial_range {Teilbereiche werden korrekt geparst} -body {
     set children [::rss-synd::xml_get_info $partial [list 0 entry] children]
     ::rss-synd::xml_list_flatten $children
 } -result "B"
+
+set savedRss {}
+
+test feed_get_rotates_user_agent_list {User-Agent-Rotation liefert unterschiedliche Werte} -setup {
+    set savedRss [namespace eval ::rss-synd { array get rss }]
+    namespace eval ::rss-synd { array set rss {} }
+    namespace eval ::rss-synd {
+        variable rss
+        set rss(rotation-test) [list \
+            "user-agent" {"Agent/1.0" "Agent/2.0" "Agent/3.0"} \
+            "user-agent-rotate" "list" \
+            "announce-type" 0 \
+            "update-interval" 0 \
+            "timeout" 1000 \
+            "url" "http://example.test/feed" \
+            "url-auth" "" \
+            "updated" 0 \
+        ]
+    }
+    namespace eval ::http {
+        set lastUserAgents {}
+        set tokenCounter 0
+    }
+} -body {
+    for {set idx 0} {$idx < 3} {incr idx} {
+        namespace eval ::rss-synd {
+            array set tmp $rss(rotation-test)
+            set tmp(updated) 0
+            set rss(rotation-test) [array get tmp]
+            unset tmp
+        }
+        ::rss-synd::feed_get
+    }
+    namespace eval ::http { set lastUserAgents }
+} -cleanup {
+    namespace eval ::rss-synd {
+        array set rss {}
+    }
+    if {[llength $savedRss] > 0} {
+        namespace eval ::rss-synd { array set rss $savedRss }
+    }
+    namespace eval ::http {
+        set lastUserAgents {}
+        set tokenCounter 0
+    }
+} -result {Agent/1.0 Agent/2.0 Agent/3.0}
+
+test next_user_agent_without_rotation_returns_first_value {Ohne Rotation wird der erste Eintrag genutzt} -body {
+    array set feed {user-agent {"Agent/1" "Agent/2"}}
+    set first [::rss-synd::next_user_agent sample feed]
+    list $first [info exists feed(user-agent-rotate-index)] [info exists feed(user-agent-last)]
+} -cleanup {
+    catch {unset feed}
+} -result {Agent/1 0 1}
+
+test next_user_agent_custom_command_updates_state {Benutzerdefinierte Rotation kann Status hinterlegen} -setup {
+    namespace eval ::uaTest {
+        variable idx 0
+        proc next {feedName settings} {
+            variable idx
+            incr idx
+            return [dict create user-agent [format "CmdUA/%d" $idx] user-agent-rotate-index $idx]
+        }
+    }
+} -body {
+    array set feed {user-agent "Fallback/0" user-agent-rotate ::uaTest::next}
+    set first [::rss-synd::next_user_agent cmd feed]
+    set state1 [list $first $feed(user-agent-rotate-index)]
+    set second [::rss-synd::next_user_agent cmd feed]
+    set state2 [list $second $feed(user-agent-rotate-index)]
+    list $state1 $state2
+} -cleanup {
+    catch {namespace delete ::uaTest}
+    catch {unset feed}
+} -result {{CmdUA/1 1} {CmdUA/2 2}}
 
 cleanupTests


### PR DESCRIPTION
## Summary
- refine feed retrieval to use a dedicated helper for selecting the next User-Agent, handling static values, lists, and custom commands robustly
- ship a curated mid-2025 User-Agent rotation list by default and document it in both README variants
- extend tests to cover static selection and custom rotation state persistence alongside the list-based round robin

## Testing
- tclsh tests/rss_synd.test

------
https://chatgpt.com/codex/tasks/task_e_68dfe4cfead4832aa85debb85b17b8e2