### PR TITLE
Add DiamantTh maintainer attribution

### DIFF
--- a/rss_synd.tcl
+++ b/rss_synd.tcl
@@ -5,7 +5,8 @@
 #
 #
 # Name: RSS & Atom Syndication Script for Eggdrop
-# Author: Pho3niX
+# Author: Pho3niX (Original)
+# Maintainer: DiamantTh <https://github.com/DiamantTh>
 # Link: https://github.com/MICE07/rss_synd.tcl
 # Tags: rss, atom, syndication
 # Updated: 03-Oct-2025


### PR DESCRIPTION
## Summary
- add DiamantTh as maintainer in the script header while keeping the original author reference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfedcfdf74832a89b4589113cd6bac