### PR TITLE
Verbesserte Fehlerbehandlung beim Laden der Einstellungen

### DIFF
--- a/rss_synd.tcl
+++ b/rss_synd.tcl
@@ -12,7 +12,7 @@
 # Updated: 03-Oct-2025
 #
 # -*- tab-width: 4; indent-tabs-mode: t; -*-
-# rss-synd.tcl -- git-198a7a4
+# rss-synd.tcl -- git-7fb5cbe
 
 #
 # Logging-Hilfsfunktionen und Einstellungen
@@ -161,9 +161,12 @@ proc ::rss-synd::log_message {level text} {
 # Include Settings
 #
 
-if {[catch {source scripts/rss-synd-settings.tcl} err]} {
-::rss-synd::log_message error "Error: Could not load 'rss-synd-settings.tcl file.'"
+set settingsPath [file normalize [file join [file dirname [info script]] rss-synd-settings.tcl]]
+if {[catch {source $settingsPath} err]} {
+        ::rss-synd::log_message error "Error: Could not load settings file '$settingsPath': $err"
+        error $err
 }
+unset settingsPath
 
 proc ::rss-synd::tls_socket {args} {
 	variable tls
@@ -237,7 +240,7 @@ proc ::rss-synd::init {args} {
 	variable version
 	variable packages
 
-	set version(number)	git-198a7a4
+	set version(number)	git-7fb5cbe
 	set version(date)	"2025-10-03"
 
         package require http

--- a/tests/rss_synd.test
+++ b/tests/rss_synd.test
@@ -10,6 +10,29 @@ proc bind {args} {}
 proc unbind {args} {}
 proc unixtime {} { clock seconds }
 
+namespace eval ::testhelpers {
+    variable logMessages {}
+
+    proc capture_putlog {text} {
+        variable logMessages
+        lappend logMessages $text
+    }
+
+    proc dummy_timer {args} {
+        return {}
+    }
+
+    proc reset_logs {} {
+        variable logMessages
+        set logMessages {}
+    }
+
+    proc get_logs {} {
+        variable logMessages
+        return $logMessages
+    }
+}
+
 set here [file dirname [info script]]
 namespace eval ::rss-synd {}
 source [file join $here .. rss_synd.tcl]
@@ -104,7 +127,7 @@ set savedRss {}
 
 test feed_get_rotates_user_agent_list {User-Agent-Rotation liefert unterschiedliche Werte} -setup {
     set savedRss [namespace eval ::rss-synd { array get rss }]
-    namespace eval ::rss-synd { array set rss {} }
+    namespace eval ::rss-synd { catch {array unset rss} }
     namespace eval ::rss-synd {
         variable rss
         set rss(rotation-test) [list \
@@ -134,9 +157,7 @@ test feed_get_rotates_user_agent_list {User-Agent-Rotation liefert unterschiedli
     }
     namespace eval ::http { set lastUserAgents }
 } -cleanup {
-    namespace eval ::rss-synd {
-        array set rss {}
-    }
+    namespace eval ::rss-synd { catch {array unset rss} }
     if {[llength $savedRss] > 0} {
         namespace eval ::rss-synd { array set rss $savedRss }
     }
@@ -174,5 +195,28 @@ test next_user_agent_custom_command_updates_state {Benutzerdefinierte Rotation k
     catch {namespace delete ::uaTest}
     catch {unset feed}
 } -result {{CmdUA/1 1} {CmdUA/2 2}}
+
+test settings_loading_failure_aborts_execution {Fehlende Einstellungen brechen das Laden mit aussagekräftiger Meldung ab} -setup {
+    set tmpdir [file normalize [file join $here tmp-missing-settings]]
+    file delete -force $tmpdir
+    file mkdir $tmpdir
+    set scriptPath [file normalize [file join $tmpdir rss_synd.tcl]]
+    file copy -force [file join $here .. rss_synd.tcl] $scriptPath
+    namespace eval ::testhelpers { reset_logs }
+    interp create rssFail
+    interp alias rssFail putlog {} ::testhelpers::capture_putlog
+    interp alias rssFail utimer {} ::testhelpers::dummy_timer
+    interp alias rssFail killutimer {} ::testhelpers::dummy_timer
+    set expectedPath [file normalize [file join [file dirname $scriptPath] rss-synd-settings.tcl]]
+    set expectedError [format {couldn't read file "%s": no such file or directory} $expectedPath]
+} -body {
+    set result [catch {interp eval rssFail [list source $scriptPath]} msg opts]
+    set logs [::testhelpers::get_logs]
+    set expectedLog [format "Error: Could not load settings file '%s': %s" $expectedPath $msg]
+    list $result [string equal $msg $expectedError] [llength $logs] [string equal [lindex $logs 0] $expectedLog]
+} -cleanup {
+    interp delete rssFail
+    file delete -force $tmpdir
+} -result {1 1 1 1}
 
 cleanupTests


### PR DESCRIPTION
## Zusammenfassung
- ermittele den absoluten Pfad zur Einstellungsdatei, lade sie mit aussagekräftiger Fehlermeldung und stoppe das Skript bei Fehlern
- aktualisiere die Versionskennung auf git-7fb5cbe
- ergänze Hilfsfunktionen und einen Testfall, der das Scheitern beim Laden der Einstellungen simuliert und überprüft

## Tests
- `tclsh tests/rss_synd.test`


------
https://chatgpt.com/codex/tasks/task_e_68e19dd0dd58832a9efdb6e982d4c693