### PR TITLE
Add config conversion helper

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -196,6 +196,6 @@ Eggdrop schreibt Skriptmeldungen in die Party-Line (DCC-Chat). Wer den Chat ruhi
 Im Pufferbetrieb werden einzelne Meldungen nicht mehr sofort angezeigt, sondern als kompakte Übersicht nach Ablauf des Intervalls ausgegeben. Mit `immediate` lässt sich das alte Verhalten jederzeit wiederherstellen.
 
 ## Kompatibilität & Versionen
-- Skriptversion git-4bda2c0 vom 03.10.2025. Die Versionsinformationen findest du direkt im Kopfbereich von `rss_synd.tcl`.
+- Skriptversion git-4bda2c0+config-convert vom 03.10.2025. Die Versionsinformationen findest du direkt im Kopfbereich von `rss_synd.tcl`.
 - Benötigt einen Eggdrop mit Tcl-Unterstützung und dem Standardpaket `http`; optionale Features setzen `base64`, `tls` und `Trf` voraus (`package require …` in `rss_synd.tcl`).
 - Für HTTPS-Verbindungen initialisiert das Skript standardmäßig TLS 1.2/1.3 und registriert eigene TLS-Sockets; über `https-allow-legacy` kannst du bei Bedarf ältere Protokolle freischalten.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,6 @@ Eggdrop writes script output to the party line (DCC chat). To reduce noise you c
 While buffered mode is active, individual log entries are grouped and only a compact digest is sent to DCC at the chosen interval. Switching back to `immediate` restores the previous behaviour.
 
 ## Compatibility & versions
-- Script version git-4bda2c0 dated 03 Oct 2025. You can find the version information in the header of `rss_synd.tcl`.
+- Script version git-4bda2c0+config-convert dated 03 Oct 2025. You can find the version information in the header of `rss_synd.tcl`.
 - Requires an Eggdrop with Tcl support and the standard `http` package; optional features rely on `base64`, `tls`, and `Trf` (`package require …` in `rss_synd.tcl`).
 - For HTTPS connections the script enables TLS 1.2/1.3 by default and registers its own TLS sockets; you can enable older protocols via `https-allow-legacy` if needed.

--- a/tests/config_convert.test
+++ b/tests/config_convert.test
@@ -1,0 +1,51 @@
+package require tcltest 2
+namespace import ::tcltest::*
+
+set here [file dirname [info script]]
+set tool [file normalize [file join $here .. tools config-convert.tcl]]
+set sampleToml [file normalize [file join $here .. rss-synd.toml]]
+
+if {![file exists $tool]} {
+    error "Konverter-Skript nicht gefunden: $tool"
+}
+
+test config_convert_toml_to_tcl {Konvertierung von TOML nach Tcl erzeugt set-Blöcke} -setup {
+    set tmpdir [makeDirectory tmp-config-convert-toml]
+    set outfile [file join $tmpdir output.tcl]
+} -body {
+    exec tclsh $tool --from toml --to tcl --input $sampleToml --output $outfile
+    set fh [open $outfile r]
+    set content [string trim [read $fh]]
+    close $fh
+    set hasDefault [regexp {^set default \{} $content]
+    set hasFeed [regexp {set rss\(msbulletins\) \{} $content]
+    list $hasDefault $hasFeed
+} -cleanup {
+    removeDirectory $tmpdir
+} -result {1 1}
+
+if {[catch {package require toml}]} {
+    ::tcltest::testConstraint haveToml 0
+} else {
+    ::tcltest::testConstraint haveToml 1
+}
+
+test config_convert_tcl_to_toml {Konvertierung einer Tcl-Datei nach TOML liefert parsebare Ausgabe} -constraints haveToml -setup {
+    set tmpdir [makeDirectory tmp-config-convert-tcl]
+    set infile [file join $tmpdir config.tcl]
+    set outfile [file join $tmpdir config.toml]
+    set fh [open $infile w]
+    puts $fh "set default {announce-output 2 channels #demo}"
+    puts $fh "set rss(example) {url http://example.test/feed update-interval 15}"
+    close $fh
+} -body {
+    exec tclsh $tool --from tcl --to toml --input $infile --output $outfile
+    set fh [open $outfile r]
+    set parsed [::toml::parse [read $fh]]
+    close $fh
+    list [dict get $parsed defaults announce-output] [dict get $parsed feeds example url]
+} -cleanup {
+    removeDirectory $tmpdir
+} -result {2 http://example.test/feed}
+
+cleanupTests

--- a/tools/config-convert.tcl
+++ b/tools/config-convert.tcl
@@ -1,0 +1,228 @@
+# config-convert.tcl -- Hilfsskript zur Konvertierung der rss_synd.tcl-Konfiguration
+#
+# Aufruf:
+#   tclsh tools/config-convert.tcl --from <toml|tcl> --to <toml|tcl> --input <Datei> --output <Datei|->
+#
+# Optionen:
+#   --from   Quellformat der Konfiguration ("toml" oder "tcl").
+#   --to     Zielformat der Konfiguration ("toml" oder "tcl").
+#   --input  Pfad zur Eingabedatei.
+#   --output Pfad zur Ausgabedatei. "-" schreibt nach stdout.
+
+namespace eval ::config_convert {
+        variable scriptDir [file dirname [file normalize [info script]]]
+        variable projectRoot [file normalize [file join $scriptDir ..]]
+
+        proc parse_args {argv} {
+                set options [dict create from {} to {} input {} output {} help 0]
+
+                while {[llength $argv] > 0} {
+                        set arg [lindex $argv 0]
+                        set argv [lrange $argv 1 end]
+                        switch -exact -- $arg {
+                                --from -
+                                --to -
+                                --input -
+                                --output {
+                                        if {[llength $argv] == 0} {
+                                                error "Fehlender Wert für Option '$arg'"
+                                        }
+                                        dict set options [string range $arg 2 end] [lindex $argv 0]
+                                        set argv [lrange $argv 1 end]
+                                }
+                                --help {
+                                        dict set options help 1
+                                }
+                                default {
+                                        error "Unbekannte Option '$arg'"
+                                }
+                        }
+                }
+
+                return $options
+        }
+
+        proc normalize_format {value} {
+                set normalized [string tolower $value]
+                if {$normalized ni {toml tcl}} {
+                        error "Unbekanntes Format '$value'"
+                }
+                return $normalized
+        }
+
+        proc ensure_toml_package {} {
+                if {[catch {package require toml} err]} {
+                        error "Das Paket 'toml' ist erforderlich: $err"
+                }
+        }
+
+        proc write_file {path data} {
+                if {$path eq "-"} {
+                        puts stdout $data
+                        return
+                }
+
+                set dir [file dirname $path]
+                if {![file exists $dir]} {
+                        if {[catch {file mkdir $dir} err]} {
+                                error "Kann Ausgabeverzeichnis '$dir' nicht erstellen: $err"
+                        }
+                }
+
+                if {[catch {set fh [open $path w]} err]} {
+                        error "Kann Ausgabedatei '$path' nicht öffnen: $err"
+                }
+                try {
+                        puts $fh $data
+                } finally {
+                        close $fh
+                }
+        }
+
+        proc format_tcl_output {configDict} {
+                set defaults {}
+                set defaultsDict [dict get $configDict defaults]
+                foreach key [lsort [dict keys $defaultsDict]] {
+                        lappend defaults $key [dict get $defaultsDict $key]
+                }
+                set lines [list [format "set default {%s}" [list {*}$defaults]] ""]
+
+                set feedsDict [dict get $configDict feeds]
+                foreach feedName [lsort [dict keys $feedsDict]] {
+                        set feedList {}
+                        set feedDict [dict get $feedsDict $feedName]
+                        foreach key [lsort [dict keys $feedDict]] {
+                                lappend feedList $key [dict get $feedDict $key]
+                        }
+                        lappend lines [format "set rss(%s) {%s}" $feedName [list {*}$feedList]]
+                }
+                return [join $lines "\n"]
+        }
+
+        proc format_toml_output {configDict} {
+                ensure_toml_package
+                return [::toml::encode $configDict]
+        }
+
+        proc ensure_runtime_stubs {} {
+                if {![llength [info commands ::putlog]]} {
+                        proc ::putlog {args} {}
+                }
+                if {![llength [info commands ::putserv]]} {
+                        proc ::putserv {args} {}
+                }
+                if {![llength [info commands ::botonchan]]} {
+                        proc ::botonchan {chan} {return 1}
+                }
+                if {![llength [info commands ::bind]]} {
+                        proc ::bind {args} {}
+                }
+                if {![llength [info commands ::unbind]]} {
+                        proc ::unbind {args} {}
+                }
+                if {![llength [info commands ::utimer]]} {
+                        proc ::utimer {args} {return {}}
+                }
+                if {![llength [info commands ::killutimer]]} {
+                        proc ::killutimer {args} {return {}}
+                }
+                if {![llength [info commands ::is_utf8_patched]]} {
+                        proc ::is_utf8_patched {} {return 0}
+                }
+        }
+
+        proc load_configuration {format inputPath} {
+                variable projectRoot
+
+                set scriptPath [file join $projectRoot rss_synd.tcl]
+                if {![file exists $scriptPath]} {
+                        error "rss_synd.tcl nicht gefunden unter '$scriptPath'"
+                }
+
+                ensure_runtime_stubs
+
+                if {[catch {source $scriptPath} err]} {
+                        error "Fehler beim Laden von '$scriptPath': $err"
+                }
+
+                namespace eval ::rss-synd { variable settings }
+                upvar 0 ::rss-synd::settings settings
+                set formatLower [string tolower $format]
+                switch -exact -- $formatLower {
+                        toml {
+                                set settings(config-format) toml
+                                set settings(config-toml-file) $inputPath
+                                set settings(config-tcl-file) {}
+                        }
+                        tcl {
+                                set settings(config-format) tcl
+                                set settings(config-tcl-file) $inputPath
+                                set settings(config-toml-file) {}
+                        }
+                }
+
+                if {[catch {::rss-synd::load_config} err]} {
+                        error "Konfiguration konnte nicht geladen werden: $err"
+                }
+
+                return [::rss-synd::configuration_to_dict]
+        }
+
+        proc main {argv} {
+                set parsed [parse_args $argv]
+                if {[dict get $parsed help]} {
+                        puts "Verwendung: tclsh tools/config-convert.tcl --from <toml|tcl> --to <toml|tcl> --input <Datei> --output <Datei|->"
+                        return 0
+                }
+
+                set from [dict get $parsed from]
+                set to [dict get $parsed to]
+                set input [dict get $parsed input]
+                set output [dict get $parsed output]
+
+                if {$from eq "" || $to eq "" || $input eq "" || $output eq ""} {
+                        error "Die Optionen --from, --to, --input und --output sind Pflicht."
+                }
+
+                set from [normalize_format $from]
+                set to [normalize_format $to]
+
+                if {$from eq $to} {
+                        error "Quell- und Zielformat dürfen nicht identisch sein."
+                }
+
+                set input [file normalize $input]
+                if {![file exists $input]} {
+                        error "Eingabedatei '$input' wurde nicht gefunden."
+                }
+
+                if {$to eq "toml"} {
+                        ensure_toml_package
+                }
+
+                set configDict [load_configuration $from $input]
+
+                switch -exact -- $to {
+                        toml {
+                                set content [format_toml_output $configDict]
+                        }
+                        tcl {
+                                set content [format_tcl_output $configDict]
+                        }
+                }
+
+                write_file $output $content
+                return 0
+        }
+}
+
+if {[info exists argv0] && [file tail [info script]] eq [file tail $argv0]} {
+        if {[catch {::config_convert::main $argv} err opts]} {
+                puts stderr "config-convert: $err"
+                if {[dict exists $opts -errorinfo]} {
+                        puts stderr [dict get $opts -errorinfo]
+                }
+                exit 1
+        }
+        exit 0
+}


### PR DESCRIPTION
## Summary
- add a tools/config-convert.tcl helper that reads rss_synd.tcl configuration files and writes Tcl or TOML
- extend rss_synd.tcl to preserve custom config paths, expose configuration_to_dict, and record the script base directory
- cover the converter with automated tests and update the documented script version banner

## Testing
- tclsh tests/rss_synd.test
- tclsh tests/config_convert.test

------
https://chatgpt.com/codex/tasks/task_e_68e1c6312450832abc8e1476e495ec77