### PR TITLE
Add debug mode configuration and diagnostics logging

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -84,6 +84,7 @@ Die folgenden Optionen kannst du global in der Default-Konfiguration oder pro Fe
 | Option | Beschreibung | Standard | Beispiel |
 | --- | --- | --- | --- |
 | `https-allow-legacy` | Erlaubt TLS 1.0/1.1 als Fallback (unsicher). | `0` | `1` |
+| `debug-mode` | Aktiviert zusätzliche Diagnoseausgaben. Erlaubte Werte sind `http` (HTTP-Anfragen protokollieren), `tls` (TLS-Handshake-Debugging) oder `all` (alle Debug-Kanäle). Mehrere Einträge können als Tcl-Liste kombiniert werden. | `{}` | `{http tls}` |
 | `log-mode` | Logging-Strategie für die Eggdrop-Konsole. `immediate` schreibt Meldungen sofort, `buffered` sammelt sie und fasst sie zusammen. | `immediate` | `buffered` |
 | `log-interval` | Minuten bis zur Ausgabe einer zusammengefassten Log-Nachricht, wenn `log-mode` auf `buffered` steht. | `5` | `10` |
 | `user-agent-rotate` | Rotationsstrategie für den User-Agent: `list` aktiviert das eingebaute Round-Robin, alternativ kann der Name einer Prozedur angegeben werden, die den nächsten Eintrag liefert. Der Aufruf erhält Feed-Namen und aktuelle Einstellungen und darf einen String oder ein Dict mit `user-agent` plus Zusatzwerten zurückgeben. | `list` | `list` / `::mein::ua::next` |
@@ -196,6 +197,6 @@ Eggdrop schreibt Skriptmeldungen in die Party-Line (DCC-Chat). Wer den Chat ruhi
 Im Pufferbetrieb werden einzelne Meldungen nicht mehr sofort angezeigt, sondern als kompakte Übersicht nach Ablauf des Intervalls ausgegeben. Mit `immediate` lässt sich das alte Verhalten jederzeit wiederherstellen.
 
 ## Kompatibilität & Versionen
-- Skriptversion git-4bda2c0 vom 03.10.2025. Die Versionsinformationen findest du direkt im Kopfbereich von `rss_synd.tcl`.
+- Skriptversion git-7b92e8a vom 07.10.2025. Die Versionsinformationen findest du direkt im Kopfbereich von `rss_synd.tcl`.
 - Benötigt einen Eggdrop mit Tcl-Unterstützung und dem Standardpaket `http`; optionale Features setzen `base64`, `tls` und `Trf` voraus (`package require …` in `rss_synd.tcl`).
 - Für HTTPS-Verbindungen initialisiert das Skript standardmäßig TLS 1.2/1.3 und registriert eigene TLS-Sockets; über `https-allow-legacy` kannst du bei Bedarf ältere Protokolle freischalten.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following options can be defined globally in the default configuration or pe
 | Option | Description | Default | Example |
 | --- | --- | --- | --- |
 | `https-allow-legacy` | Allows TLS 1.0/1.1 as a fallback (insecure). | `0` | `1` |
+| `debug-mode` | Enables verbose diagnostics. Provide a Tcl list with `http` for HTTP request logging, `tls` for TLS handshake diagnostics, or `all` to enable every debug channel. | `{}` | `{http tls}` |
 | `log-mode` | Logging strategy for Eggdrop’s console output. Use `immediate` for direct `putlog` calls or `buffered` to collect messages and emit summaries. | `immediate` | `buffered` |
 | `log-interval` | Interval in minutes before buffered log summaries are flushed. Ignored when `log-mode` is `immediate`. | `5` | `10` |
 | `user-agent-rotate` | Rotation strategy for the User-Agent list: use `list` for round-robin or pass a command name that returns the next agent. The command receives the feed name and current settings and may return a string or a dict containing `user-agent` plus extra state. | `list` | `list` / `::my::ua::next` |
@@ -197,6 +198,6 @@ Eggdrop writes script output to the party line (DCC chat). To reduce noise you c
 While buffered mode is active, individual log entries are grouped and only a compact digest is sent to DCC at the chosen interval. Switching back to `immediate` restores the previous behaviour.
 
 ## Compatibility & versions
-- Script version git-4bda2c0 dated 03 Oct 2025. You can find the version information in the header of `rss_synd.tcl`.
+- Script version git-7b92e8a dated 07 Oct 2025. You can find the version information in the header of `rss_synd.tcl`.
 - Requires an Eggdrop with Tcl support and the standard `http` package; optional features rely on `base64`, `tls`, and `Trf` (`package require …` in `rss_synd.tcl`).
 - For HTTPS connections the script enables TLS 1.2/1.3 by default and registers its own TLS sockets; you can enable older protocols via `https-allow-legacy` if needed.

--- a/rss-synd-settings.tcl
+++ b/rss-synd-settings.tcl
@@ -23,4 +23,8 @@ namespace eval ::rss-synd {
     if {![info exists settings(config-tcl-file)]} {
         set settings(config-tcl-file) ""
     }
+
+    if {![info exists settings(debug-mode)]} {
+        set settings(debug-mode) {}
+    }
 }

--- a/tests/rss_synd.test
+++ b/tests/rss_synd.test
@@ -2,7 +2,7 @@ package require tcltest 2
 namespace import ::tcltest::*
 
 # Stubs für Eggdrop-spezifische Funktionen
-proc putlog {args} {}
+proc putlog {args} { ::testhelpers::capture_putlog {*}$args }
 proc putserv {args} {}
 proc botonchan {chan} { return 1 }
 proc is_utf8_patched {} { return 0 }
@@ -13,8 +13,9 @@ proc unixtime {} { clock seconds }
 namespace eval ::testhelpers {
     variable logMessages {}
 
-    proc capture_putlog {text} {
+    proc capture_putlog {args} {
         variable logMessages
+        set text [join $args " "]
         lappend logMessages $text
     }
 
@@ -55,9 +56,107 @@ namespace eval ::http {
         incr tokenCounter
         return "token$tokenCounter"
     }
+
+    proc register {args} { return {} }
+    proc unregister {args} { return {} }
+}
+
+namespace eval ::tls {
+    variable debugCalls {}
+
+    proc init {args} { return {} }
+    proc debug {flag} {
+        variable debugCalls
+        lappend debugCalls $flag
+        return {}
+    }
+    proc socket {args} { return sock }
 }
 
 namespace eval ::rss-synd { variable packages }
+
+test configure_debug_all_enables_http_and_tls {Konfiguration "all" aktiviert HTTP- und TLS-Debug-Flag} -setup {
+    namespace eval ::rss-synd { catch {array unset debugOptions} }
+} -body {
+    ::rss-synd::configure_debug [list debug-mode {all}]
+    namespace eval ::rss-synd { list $debugOptions(http) $debugOptions(tls) }
+} -cleanup {
+    namespace eval ::rss-synd { array set debugOptions {http 0 tls 0} }
+} -result {1 1}
+
+test setup_tls_calls_tls_debug_when_enabled {TLS-Debug wird aktiviert und protokolliert} -setup {
+    namespace eval ::rss-synd { catch {array unset debugOptions} }
+    namespace eval ::tls { set debugCalls {} }
+    ::testhelpers::reset_logs
+} -body {
+    ::rss-synd::configure_debug [list debug-mode {tls}]
+    ::testhelpers::reset_logs
+    ::rss-synd::setup_tls
+    set debugCount [llength [namespace eval ::tls { set debugCalls }]]
+    set logs [::testhelpers::get_logs]
+    set found 0
+    foreach entry $logs {
+        if {[string match *TLS-Debugmodus* $entry]} {
+            set found 1
+        }
+    }
+    list $debugCount $found
+} -cleanup {
+    namespace eval ::rss-synd { array set debugOptions {http 0 tls 0} }
+    ::testhelpers::reset_logs
+} -result {1 1}
+
+test feed_get_emits_http_debug_log_when_enabled {HTTP-Debug protokolliert URL, Timeout und Header} -setup {
+    set savedRssExists [namespace eval ::rss-synd { array exists rss }]
+    if {$savedRssExists} {
+        set savedRss [namespace eval ::rss-synd { array get rss }]
+    } else {
+        set savedRss {}
+    }
+    namespace eval ::rss-synd {
+        catch {array unset rss}
+        array set rss {}
+        set rss(debugfeed) [list \
+            "url" "http://example.test/feed" \
+            "timeout" 4200 \
+            "update-interval" 0 \
+            "announce-type" 0 \
+            "trigger-type" "0:2" \
+            "user-agent" {"Agent/1"} \
+            "user-agent-rotate" "" \
+            "url-auth" "dGVzdDp0b2tlbg==" \
+            "enable-gzip" 1 \
+            "updated" 0 \
+            "max-depth" 5 \
+        ]
+    }
+    ::testhelpers::reset_logs
+    namespace eval ::http { set tokenCounter 0 }
+} -body {
+    ::rss-synd::configure_debug [list debug-mode {http}]
+    ::testhelpers::reset_logs
+    ::rss-synd::feed_get
+    set logs [::testhelpers::get_logs]
+    set idx [lsearch -glob $logs "*HTTP GET*http://example.test/feed*"]
+    set hasMsg [expr {$idx >= 0}]
+    set headersLogged 0
+    if {$hasMsg} {
+        set entry [lindex $logs $idx]
+        if {[string match *timeout=4200* $entry] && [string match *Authorization* $entry] && [string match *Accept-Encoding* $entry]} {
+            set headersLogged 1
+        }
+    }
+    list $hasMsg $headersLogged
+} -cleanup {
+    namespace eval ::rss-synd {
+        catch {array unset rss}
+        if {$savedRssExists} {
+            array set rss $savedRss
+        }
+        array set debugOptions {http 0 tls 0}
+    }
+    ::testhelpers::reset_logs
+} -result {1 1}
 
 set sampleFeed {<rss><channel><title>Demo</title><item><title>Erster</title></item><item><title>Zweiter</title></item><item><title>Dritter</title></item></channel></rss>}
 


### PR DESCRIPTION
## Summary
- add a `debug-mode` setting plus runtime support to collect HTTP/TLS debug flags during initialization
- emit optional TLS handshake diagnostics (including `::tls::debug` activation) and detailed HTTP request logs when debug mode is active
- cover the new behaviour with unit tests and document valid debug values in both READMEs

## Testing
- tclsh tests/rss_synd.test

------
https://chatgpt.com/codex/tasks/task_e_68e1c23580a0832aa334c26de3fd0463