### PR TITLE
Escape log level markers in flush_log_queue

### DIFF
--- a/rss_synd.tcl
+++ b/rss_synd.tcl
@@ -12,7 +12,7 @@
 # Updated: 03-Oct-2025
 #
 # -*- tab-width: 4; indent-tabs-mode: t; -*-
-# rss-synd.tcl -- git-4bda2c0+config-convert
+# rss-synd.tcl -- git-4bda2c0+log-escape
 
 #
 # Logging-Hilfsfunktionen und Einstellungen
@@ -121,9 +121,9 @@ proc ::rss-synd::flush_log_queue {} {
 	if {[llength $summaryParts] > 0} {
 		append summary " (" [join $summaryParts ", "] ")"
 	}
-	append summary ", Erste [$firstLevel]: $firstText"
+	append summary ", Erste " {\[} $firstLevel {\]: } $firstText
 	if {$total > 1} {
-		append summary " – Letzte [$lastLevel]: $lastText"
+		append summary " – Letzte " {\[} $lastLevel {\]: } $lastText
 	}
 	putlog $summary
 	set logQueue {}
@@ -484,8 +484,8 @@ proc ::rss-synd::init {args} {
 	variable version
 	variable packages
 
-	set version(number)	git-4bda2c0
-	set version(date)	"2025-10-03"
+	set version(number)	git-4bda2c0+log-escape
+	set version(date)	"2025-10-05"
 
         package require http
         set packages(base64) [catch {package require base64}]; # http auth

--- a/tests/rss_synd.test
+++ b/tests/rss_synd.test
@@ -2,7 +2,6 @@ package require tcltest 2
 namespace import ::tcltest::*
 
 # Stubs für Eggdrop-spezifische Funktionen
-proc putlog {args} {}
 proc putserv {args} {}
 proc botonchan {chan} { return 1 }
 proc is_utf8_patched {} { return 0 }
@@ -31,6 +30,10 @@ namespace eval ::testhelpers {
         variable logMessages
         return $logMessages
     }
+}
+
+proc putlog {args} {
+    ::testhelpers::capture_putlog [join $args " "]
 }
 
 set here [file dirname [info script]]
@@ -66,6 +69,39 @@ array set feed {}
 set feed(announce-output) 2
 set feed(trigger-output) 3
 ::rss-synd::feed_info $parsedFeed feed
+
+test flush_log_queue_escapes_level_names {flush_log_queue maskiert Level-Präfixe korrekt} -setup {
+    ::testhelpers::reset_logs
+    set savedState [namespace eval ::rss-synd {
+        variable logQueue
+        variable logTimer
+        list $logQueue $logTimer
+    }]
+    namespace eval ::rss-synd {
+        variable logQueue
+        variable logTimer
+        set logQueue [list \
+            [dict create level warning text "Erste Meldung"] \
+            [dict create level error text "Letzte Meldung"]
+        ]
+        set logTimer ""
+    }
+} -body {
+    ::rss-synd::flush_log_queue
+    set logs [::testhelpers::get_logs]
+    set summary [lindex $logs 0]
+    set warnIndex [string first {\[warning\]} $summary]
+    set errorIndex [string first {\[error\]} $summary]
+    list [llength $logs] [expr {$warnIndex >= 0}] [expr {$errorIndex >= 0}]
+} -cleanup {
+    namespace eval ::rss-synd {
+        variable logQueue
+        variable logTimer
+        set logQueue [lindex $savedState 0]
+        set logTimer [lindex $savedState 1]
+    }
+    ::testhelpers::reset_logs
+} -result {1 1 1}
 
 # Test: xml_list_create kann Werte korrekt auslesen
 set titlePath [::rss-synd::xml_join_tags $feed(tag-feed) $feed(tag-list) 1 $feed(tag-name) 0 title]


### PR DESCRIPTION
## Summary
- escape the buffered log summary brackets to emit literal level markers and bump the reported script version
- capture putlog invocations in the test suite and cover flush_log_queue output to guard the new formatting

## Testing
- tclsh tests/rss_synd.test

------
https://chatgpt.com/codex/tasks/task_e_68e1d0d69638832a92cc316aa88b32dd