### PR TITLE
Debug-Modus und Tests vervollständigt

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -84,6 +84,7 @@ Die folgenden Optionen kannst du global in der Default-Konfiguration oder pro Fe
 | Option | Beschreibung | Standard | Beispiel |
 | --- | --- | --- | --- |
 | `https-allow-legacy` | Erlaubt TLS 1.0/1.1 als Fallback (unsicher). | `0` | `1` |
+| `debug-mode` | Aktiviert detailliertes Debugging. Liste mit `http`, `tls` oder `all`. `http` protokolliert URL, Timeout und Header der Abrufe, `tls` versucht `::tls::debug` zu nutzen und protokolliert andernfalls die verwendeten TLS-Optionen. | `{}` | `{http tls}` |
 | `log-mode` | Logging-Strategie für die Eggdrop-Konsole. `immediate` schreibt Meldungen sofort, `buffered` sammelt sie und fasst sie zusammen. | `immediate` | `buffered` |
 | `log-interval` | Minuten bis zur Ausgabe einer zusammengefassten Log-Nachricht, wenn `log-mode` auf `buffered` steht. | `5` | `10` |
 | `user-agent-rotate` | Rotationsstrategie für den User-Agent: `list` aktiviert das eingebaute Round-Robin, alternativ kann der Name einer Prozedur angegeben werden, die den nächsten Eintrag liefert. Der Aufruf erhält Feed-Namen und aktuelle Einstellungen und darf einen String oder ein Dict mit `user-agent` plus Zusatzwerten zurückgeben. | `list` | `list` / `::mein::ua::next` |
@@ -196,6 +197,6 @@ Eggdrop schreibt Skriptmeldungen in die Party-Line (DCC-Chat). Wer den Chat ruhi
 Im Pufferbetrieb werden einzelne Meldungen nicht mehr sofort angezeigt, sondern als kompakte Übersicht nach Ablauf des Intervalls ausgegeben. Mit `immediate` lässt sich das alte Verhalten jederzeit wiederherstellen.
 
 ## Kompatibilität & Versionen
-- Skriptversion git-4bda2c0+config-convert vom 03.10.2025. Die Versionsinformationen findest du direkt im Kopfbereich von `rss_synd.tcl`.
+- Skriptversion git-4bda2c0+debug-modes vom 04.10.2025. Die Versionsinformationen findest du direkt im Kopfbereich von `rss_synd.tcl`.
 - Benötigt einen Eggdrop mit Tcl-Unterstützung und dem Standardpaket `http`; optionale Features setzen `base64`, `tls` und `Trf` voraus (`package require …` in `rss_synd.tcl`).
 - Für HTTPS-Verbindungen initialisiert das Skript standardmäßig TLS 1.2/1.3 und registriert eigene TLS-Sockets; über `https-allow-legacy` kannst du bei Bedarf ältere Protokolle freischalten.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following options can be defined globally in the default configuration or pe
 | Option | Description | Default | Example |
 | --- | --- | --- | --- |
 | `https-allow-legacy` | Allows TLS 1.0/1.1 as a fallback (insecure). | `0` | `1` |
+| `debug-mode` | Enables verbose debugging. Pass a Tcl list with any of `http`, `tls`, or `all`. `http` logs outgoing request details, while `tls` activates `::tls::debug` (and logs the applied TLS options if the command is missing). | `{}` | `{http tls}` |
 | `log-mode` | Logging strategy for Eggdrop’s console output. Use `immediate` for direct `putlog` calls or `buffered` to collect messages and emit summaries. | `immediate` | `buffered` |
 | `log-interval` | Interval in minutes before buffered log summaries are flushed. Ignored when `log-mode` is `immediate`. | `5` | `10` |
 | `user-agent-rotate` | Rotation strategy for the User-Agent list: use `list` for round-robin or pass a command name that returns the next agent. The command receives the feed name and current settings and may return a string or a dict containing `user-agent` plus extra state. | `list` | `list` / `::my::ua::next` |
@@ -197,6 +198,6 @@ Eggdrop writes script output to the party line (DCC chat). To reduce noise you c
 While buffered mode is active, individual log entries are grouped and only a compact digest is sent to DCC at the chosen interval. Switching back to `immediate` restores the previous behaviour.
 
 ## Compatibility & versions
-- Script version git-4bda2c0+config-convert dated 03 Oct 2025. You can find the version information in the header of `rss_synd.tcl`.
+- Script version git-4bda2c0+debug-modes dated 04 Oct 2025. You can find the version information in the header of `rss_synd.tcl`.
 - Requires an Eggdrop with Tcl support and the standard `http` package; optional features rely on `base64`, `tls`, and `Trf` (`package require …` in `rss_synd.tcl`).
 - For HTTPS connections the script enables TLS 1.2/1.3 by default and registers its own TLS sockets; you can enable older protocols via `https-allow-legacy` if needed.

--- a/rss-synd-settings.tcl
+++ b/rss-synd-settings.tcl
@@ -23,4 +23,8 @@ namespace eval ::rss-synd {
     if {![info exists settings(config-tcl-file)]} {
         set settings(config-tcl-file) ""
     }
+
+    if {![info exists settings(debug-mode)]} {
+        set settings(debug-mode) {}
+    }
 }

--- a/tests/rss_synd.test
+++ b/tests/rss_synd.test
@@ -33,6 +33,12 @@ namespace eval ::testhelpers {
     }
 }
 
+proc putlog {text} {
+    ::testhelpers::capture_putlog $text
+}
+
+::testhelpers::reset_logs
+
 set here [file dirname [info script]]
 namespace eval ::rss-synd {}
 source [file join $here .. rss_synd.tcl]
@@ -40,6 +46,7 @@ source [file join $here .. rss_synd.tcl]
 namespace eval ::http {
     variable lastUserAgents {}
     variable tokenCounter 0
+    variable statusByToken {}
 
     proc config {args} {
         variable lastUserAgents
@@ -52,12 +59,57 @@ namespace eval ::http {
 
     proc geturl {url args} {
         variable tokenCounter
+        variable statusByToken
         incr tokenCounter
-        return "token$tokenCounter"
+        set token "token$tokenCounter"
+        if {![dict exists $statusByToken $token]} {
+            set statusByToken [dict replace $statusByToken $token 200]
+        }
+        return $token
+    }
+
+    proc register {args} { return {} }
+    proc unregister {args} { return {} }
+    proc cleanup {token} {
+        variable statusByToken
+        if {[dict exists $statusByToken $token]} {
+            set statusByToken [dict remove $statusByToken $token]
+        }
+    }
+
+    proc ncode {token} {
+        variable statusByToken
+        if {[dict exists $statusByToken $token]} {
+            return [dict get $statusByToken $token]
+        }
+        return 200
     }
 }
 
 namespace eval ::rss-synd { variable packages }
+
+namespace eval ::tls {
+    variable initArgs {}
+    variable debugCalls {}
+
+    proc init {args} {
+        variable initArgs
+        set initArgs $args
+        return {}
+    }
+
+    proc debug {args} {
+        variable debugCalls
+        # Speichere die übergebenen Argumente je Aufruf als Liste,
+        # damit Tests die erwarteten Parameter exakt prüfen können.
+        lappend debugCalls [list {*}$args]
+        return {}
+    }
+
+    proc socket {args} {
+        return socket
+    }
+}
 
 set sampleFeed {<rss><channel><title>Demo</title><item><title>Erster</title></item><item><title>Zweiter</title></item><item><title>Dritter</title></item></channel></rss>}
 
@@ -110,6 +162,258 @@ test resolve_redirect_fallback_parent {Fallback-Auflösung unterstützt '..'} -b
     namespace eval ::rss-synd { set packages(uri) 1 }
     ::rss-synd::resolve_redirect "http://example.com/base/dir/index" "../next.xml"
 } -result "http://example.com/base/next.xml"
+
+
+test configure_debug_defaults_to_disabled {Leere Debug-Liste deaktiviert alle Flags} -body {
+    set ::test_savedDebugMode_default [namespace eval ::rss-synd {
+        variable settings
+        set value {}
+        if {[info exists settings(debug-mode)]} {
+            set value $settings(debug-mode)
+        }
+        set value
+    }]
+    ::testhelpers::reset_logs
+    set result [namespace eval ::rss-synd {
+        variable settings
+        set settings(debug-mode) {}
+        ::rss-synd::configure_debug
+        variable debugOptions
+        list $debugOptions(http) $debugOptions(tls)
+    }]
+    return $result
+} -cleanup {
+    if {[info exists ::test_savedDebugMode_default]} {
+        namespace eval ::rss-synd {
+            variable settings
+            set settings(debug-mode) $::test_savedDebugMode_default
+            ::rss-synd::configure_debug
+        }
+        unset ::test_savedDebugMode_default
+    }
+    ::testhelpers::reset_logs
+} -result {0 0}
+
+test configure_debug_all_enables_all_flags {'all' aktiviert HTTP- und TLS-Debug} -body {
+    set ::test_savedDebugMode_all [namespace eval ::rss-synd {
+        variable settings
+        set value {}
+        if {[info exists settings(debug-mode)]} {
+            set value $settings(debug-mode)
+        }
+        set value
+    }]
+    ::testhelpers::reset_logs
+    set result [namespace eval ::rss-synd {
+        variable settings
+        set settings(debug-mode) {all}
+        ::rss-synd::configure_debug
+        variable debugOptions
+        list $debugOptions(http) $debugOptions(tls)
+    }]
+    return $result
+} -cleanup {
+    if {[info exists ::test_savedDebugMode_all]} {
+        namespace eval ::rss-synd {
+            variable settings
+            set settings(debug-mode) $::test_savedDebugMode_all
+            ::rss-synd::configure_debug
+        }
+        unset ::test_savedDebugMode_all
+    }
+    ::testhelpers::reset_logs
+} -result {1 1}
+
+test setup_tls_activates_tls_debug_command {TLS-Debug ruft ::tls::debug auf und meldet die Aktivierung} -body {
+    set ::test_savedDebugMode_tls [namespace eval ::rss-synd {
+        variable settings
+        set value {}
+        if {[info exists settings(debug-mode)]} {
+            set value $settings(debug-mode)
+        }
+        set value
+    }]
+    namespace eval ::rss-synd {
+        variable settings
+        catch {array unset tls}
+        set settings(debug-mode) {tls}
+        ::rss-synd::configure_debug
+    }
+    namespace eval ::tls { set debugCalls {} }
+    namespace eval ::http { set statusByToken {}; set tokenCounter 0 }
+    ::testhelpers::reset_logs
+    set setupResult [::rss-synd::setup_tls]
+    set logs [::testhelpers::get_logs]
+    set debugCalls [namespace eval ::tls { set debugCalls }]
+    set result [list $setupResult [expr {[llength $debugCalls] == 1 && [lindex $debugCalls 0] == 1}] [string match "\u0002RSS Debug\u0002: TLS-Debugausgabe*" [lindex $logs end]]]
+    return $result
+} -cleanup {
+    namespace eval ::rss-synd { catch {array unset tls} }
+    if {[info exists ::test_savedDebugMode_tls]} {
+        namespace eval ::rss-synd {
+            variable settings
+            set settings(debug-mode) $::test_savedDebugMode_tls
+            ::rss-synd::configure_debug
+        }
+        unset ::test_savedDebugMode_tls
+    }
+    namespace eval ::tls { set debugCalls {} }
+    ::testhelpers::reset_logs
+} -result {1 1 1}
+
+test setup_tls_logs_options_without_tls_debug {Fehlt ::tls::debug, werden TLS-Optionen protokolliert} -body {
+    set ::test_savedDebugMode_tlsFallback [namespace eval ::rss-synd {
+        variable settings
+        set value {}
+        if {[info exists settings(debug-mode)]} {
+            set value $settings(debug-mode)
+        }
+        set value
+    }]
+    namespace eval ::rss-synd {
+        variable settings
+        catch {array unset tls}
+        set settings(debug-mode) {tls}
+        ::rss-synd::configure_debug
+    }
+    namespace eval ::tls { set debugCalls {} }
+    namespace eval ::http { set statusByToken {}; set tokenCounter 0 }
+    if {[info commands ::tls::debug] ne ""} {
+        rename ::tls::debug ::tls::debug_saved
+        set ::test_savedTlsDebugRestored 1
+    }
+    ::testhelpers::reset_logs
+    set setupResult [::rss-synd::setup_tls]
+    set logs [::testhelpers::get_logs]
+    set result [list $setupResult [llength $logs] [string match "\u0002RSS Debug\u0002: TLS-Debugmodus angefordert,*" [lindex $logs 0]] [string match "\u0002RSS Debug\u0002: Verwendete TLS-Handshake-Optionen:*" [lindex $logs 1]]]
+    return $result
+} -cleanup {
+    if {[info commands ::tls::debug_saved] ne ""} {
+        rename ::tls::debug_saved ::tls::debug
+        catch {unset ::test_savedTlsDebugRestored}
+    }
+    namespace eval ::rss-synd { catch {array unset tls} }
+    if {[info exists ::test_savedDebugMode_tlsFallback]} {
+        namespace eval ::rss-synd {
+            variable settings
+            set settings(debug-mode) $::test_savedDebugMode_tlsFallback
+            ::rss-synd::configure_debug
+        }
+        unset ::test_savedDebugMode_tlsFallback
+    }
+    namespace eval ::tls { set debugCalls {} }
+    ::testhelpers::reset_logs
+} -result {1 2 1 1}
+
+test feed_get_logs_http_debug_info {HTTP-Debug protokolliert URL, Timeout und Header} -body {
+    set ::test_savedRssDebug [namespace eval ::rss-synd {
+        if {[array exists rss]} {
+            array get rss
+        } else {
+            {}
+        }
+    }]
+    namespace eval ::rss-synd {
+        catch {array unset rss}
+        variable rss
+        set rss(debug-log) {
+            user-agent {"Agent/1"}
+            user-agent-rotate list
+            announce-type 0
+            update-interval 0
+            timeout 1500
+            url http://example.test/debug
+            url-auth ""
+            updated 0
+        }
+    }
+    set ::test_savedDebugMode_http [namespace eval ::rss-synd {
+        variable settings
+        set value {}
+        if {[info exists settings(debug-mode)]} {
+            set value $settings(debug-mode)
+        }
+        set value
+    }]
+    namespace eval ::rss-synd {
+        variable settings
+        set settings(debug-mode) {http}
+        ::rss-synd::configure_debug
+    }
+    namespace eval ::http { set statusByToken {}; set tokenCounter 0 }
+    ::testhelpers::reset_logs
+    ::rss-synd::feed_get
+    set logs [::testhelpers::get_logs]
+    set result [list [llength $logs] [string match "\u0002RSS Debug\u0002: HTTP-Abruf für '* (Timeout: 1500 ms, Header: keine)" [lindex $logs 0]]]
+    return $result
+} -cleanup {
+    namespace eval ::rss-synd { catch {array unset rss} }
+    if {[info exists ::test_savedRssDebug] && [llength $::test_savedRssDebug] > 0} {
+        namespace eval ::rss-synd { array set rss $::test_savedRssDebug }
+    }
+    if {[info exists ::test_savedDebugMode_http]} {
+        namespace eval ::rss-synd {
+            variable settings
+            set settings(debug-mode) $::test_savedDebugMode_http
+            ::rss-synd::configure_debug
+        }
+        unset ::test_savedDebugMode_http
+    }
+    catch {unset ::test_savedRssDebug}
+    namespace eval ::http { set statusByToken {}; set tokenCounter 0 }
+    ::testhelpers::reset_logs
+} -result {1 1}
+
+test feed_callback_logs_redirect_http_debug {HTTP-Debug gibt Informationen zum Redirect-Abruf aus} -body {
+    set ::test_savedDebugMode_redirect [namespace eval ::rss-synd {
+        variable settings
+        set value {}
+        if {[info exists settings(debug-mode)]} {
+            set value $settings(debug-mode)
+        }
+        set value
+    }]
+    namespace eval ::rss-synd {
+        variable settings
+        set settings(debug-mode) {http}
+        ::rss-synd::configure_debug
+    }
+    namespace eval ::http { set statusByToken {}; set tokenCounter 0 }
+    ::testhelpers::reset_logs
+    array set ::tokenRedirect {
+        status ok
+        http {HTTP/1.1 302 Found}
+        meta {Location /redirect.xml}
+        url http://example.test/source
+    }
+    namespace eval ::http {
+        variable statusByToken
+        set statusByToken [dict replace $statusByToken tokenRedirect 302]
+    }
+    set feedlist {
+        url http://example.test/source
+        timeout 2000
+        headers {Authorization {Basic token}}
+        depth 0
+        max-depth 5
+    }
+    set callbackResult [::rss-synd::feed_callback $feedlist tokenRedirect]
+    set logs [::testhelpers::get_logs]
+    set result [list $callbackResult [llength $logs] [string match "\u0002RSS Debug\u0002: HTTP-Redirect-Abruf für '* (Timeout: 2000 ms, Header: Authorization: Basic token)" [lindex $logs 0]]]
+    return $result
+} -cleanup {
+    catch {array unset ::tokenRedirect}
+    namespace eval ::http { set statusByToken {}; set tokenCounter 0 }
+    if {[info exists ::test_savedDebugMode_redirect]} {
+        namespace eval ::rss-synd {
+            variable settings
+            set settings(debug-mode) $::test_savedDebugMode_redirect
+            ::rss-synd::configure_debug
+        }
+        unset ::test_savedDebugMode_redirect
+    }
+    ::testhelpers::reset_logs
+} -result {1 1 1}
 
 # Test: xml_list_create kann auf Teilbereiche beschränkt werden
 set childXml "<root><entry>A</entry><entry>B</entry></root>"


### PR DESCRIPTION
## Zusammenfassung
- ergänze die Debug-Konfigurationslogik um `configure_debug`, HTTP/TLS-Protokollierung und Versions-Update
- erweitere die Standard-Konfiguration und Dokumentation um das neue `debug-mode`-Setting
- baue Tests und Stubs aus, damit TLS-/HTTP-Debugfälle zuverlässig geprüft werden

## Tests
- `tclsh tests/rss_synd.test`


------
https://chatgpt.com/codex/tasks/task_e_68e1d0ca9ac0832a98ed10eef99af3fd