### PR TITLE
Setze Default für debug-mode im Settings-Namespace

### DIFF
--- a/rss-synd-settings.tcl
+++ b/rss-synd-settings.tcl
@@ -25,5 +25,6 @@ namespace eval ::rss-synd {
     }
 
     if {![info exists settings(debug-mode)]} {
-
+        set settings(debug-mode) ""
+    }
 }


### PR DESCRIPTION
## Summary
- setze einen leeren Standardwert für `settings(debug-mode)` wenn er noch nicht existiert
- stelle sicher, dass der Namespace-Block korrekt geschlossen wird

## Testing
- tclsh <<'EOF'
source rss-synd-settings.tcl
EOF

------
https://chatgpt.com/codex/tasks/task_e_68e2675e2e88832aa9999c0abdd17961