### PR TITLE
Entferne Debug-Suffix aus Versionsinformationen

### DIFF
--- a/rss_synd.tcl
+++ b/rss_synd.tcl
@@ -12,7 +12,7 @@
 # Updated: 12-Oct-2025
 #
 # -*- tab-width: 4; indent-tabs-mode: t; -*-
-# rss-synd.tcl -- git-8ac21f0+debug-mode
+# rss-synd.tcl -- git-8ac21f0
 # Updated: 04-Oct-2025
 #
 # -*- tab-width: 4; indent-tabs-mode: t; -*-


### PR DESCRIPTION
## Zusammenfassung
- aktualisiere den Dateikopf von rss_synd.tcl auf die aktuelle Versionsnummer ohne Debug-Zusatz

## Tests
- keine

------
https://chatgpt.com/codex/tasks/task_e_68e26bbd1748832a8ef9531cbde0a74b